### PR TITLE
Fix language-dependent quality menu detection and looping

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -25,8 +25,8 @@ async function changeQuality() {
         "isTurnedOn",
         "isPaidUser",
     ]);
-    const ads = getSingleElementByXpath(
-        '//*[contains(@id, "simple-ad-badge") and contains(text(), "Ad ")]',
+    const ads = document.querySelector(".ytp-ad-player-overlay, .ytp-ad-message-container, #simple-ad-badge") || getSingleElementByXpath(
+        '//*[contains(@id, "simple-ad-badge")]',
     );
 
     if (!response.isTurnedOn || changedQuality || ads != null) return;
@@ -37,15 +37,38 @@ async function changeQuality() {
     ) as HTMLButtonElement;
 
     // check if settings button is visible
-    if (settingsButton.offsetHeight === 0 || settingsButton.offsetWidth === 0)
+    if (!settingsButton || settingsButton.offsetHeight === 0 || settingsButton.offsetWidth === 0)
         return;
 
-    settingsButton?.click();
+    // Only click if the menu is not already open to prevent looping
+    const isMenuOpen = settingsButton.getAttribute("aria-expanded") === "true";
+    if (!isMenuOpen) {
+        settingsButton.click();
+        await timer(200);
+    }
 
-    const qualityMenu = getSingleElementByXpath(
-        '//div[text()="Quality"]',
-    ) as HTMLDivElement;
-    qualityMenu?.click();
+    // Find the Quality menu item in a language-independent way
+    const menuItems = document.querySelectorAll(".ytp-menuitem");
+    let qualityMenu: HTMLDivElement | null = null;
+
+    for (const item of Array.from(menuItems) as HTMLDivElement[]) {
+        const label = item.querySelector(".ytp-menuitem-label")?.textContent;
+        const content = item.querySelector(".ytp-menuitem-content")?.textContent;
+        const hasQualityIcon = item.querySelector('path[d*="M15,17h-2v-3h2V17z"]');
+
+        if (
+            label === "Quality" ||
+            hasQualityIcon ||
+            (content && /^\d+p|Auto/.test(content))
+        ) {
+            qualityMenu = item;
+            break;
+        }
+    }
+
+    if (!qualityMenu) return;
+    qualityMenu.click();
+    await timer(100);
 
     const qualityMenuItemsContainer = document.querySelector(
         ".ytp-quality-menu .ytp-panel-menu",


### PR DESCRIPTION
This PR addresses the issue where the extension gets stuck in a loop of opening and closing the settings menu when the YouTube display language is set to something other than English (e.g., Japanese).

### Changes:
1. **Robust Quality Menu Detection**: Instead of relying on the exact text 'Quality', the code now looks for the specific Quality icon SVG path and standard quality labels (like '1080p' or 'Auto') in the menu content.
2. **Language-Independent Ad Detection**: Updated ad detection to use internal YouTube IDs and classes instead of English text badges.
3. **Loop Prevention**: Added a check for the 'aria-expanded' attribute on the settings button. The extension will now only click the settings button if the menu is not already open, preventing the toggle loop reported by users.

This should make the extension work seamlessly across all YouTube supported languages.