### PR TITLE
Fix: Language-agnostic quality selection and loop prevention

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -25,8 +25,8 @@ async function changeQuality() {
         "isTurnedOn",
         "isPaidUser",
     ]);
-    const ads = getSingleElementByXpath(
-        '//*[contains(@id, "simple-ad-badge") and contains(text(), "Ad ")]',
+    const ads = document.querySelector(".ytp-ad-player-overlay, .ytp-ad-message-container, #simple-ad-badge") || getSingleElementByXpath(
+        '//*[contains(@id, "simple-ad-badge")]',
     );
 
     if (!response.isTurnedOn || changedQuality || ads != null) return;
@@ -37,15 +37,36 @@ async function changeQuality() {
     ) as HTMLButtonElement;
 
     // check if settings button is visible
-    if (settingsButton.offsetHeight === 0 || settingsButton.offsetWidth === 0)
+    if (!settingsButton || settingsButton.offsetHeight === 0 || settingsButton.offsetWidth === 0)
         return;
 
-    settingsButton?.click();
+    // Only click if the menu is not already open to prevent looping
+    const isMenuOpen = settingsButton.getAttribute("aria-expanded") === "true";
+    if (!isMenuOpen) {
+        settingsButton.click();
+        await timer(200);
+    }
 
-    const qualityMenu = getSingleElementByXpath(
-        '//div[text()="Quality"]',
-    ) as HTMLDivElement;
-    qualityMenu?.click();
+    // Find the Quality menu item in a language-independent way
+    const menuItems = document.querySelectorAll(".ytp-menuitem");
+    let qualityMenu: HTMLDivElement | null = null;
+
+    for (const item of Array.from(menuItems) as HTMLDivElement[]) {
+        const label = item.querySelector(".ytp-menuitem-label")?.textContent;
+        const content = item.querySelector(".ytp-menuitem-content")?.textContent;
+
+        if (
+            label === "Quality" ||
+            label === "画質" || // Japanese
+            (content && (/^\d+p|Auto|自動/.test(content)))
+        ) {
+            qualityMenu = item;
+            break;
+        }
+    }
+
+    if (!qualityMenu) return;
+    qualityMenu.click();
 
     const qualityMenuItemsContainer = document.querySelector(
         ".ytp-quality-menu .ytp-panel-menu",
@@ -60,7 +81,7 @@ async function changeQuality() {
             qualityMenuItems[0].click();
         } else {
             for (const qualityMenuItem of [...qualityMenuItems]) {
-                if (!qualityMenuItem.textContent?.includes("Premium")) {
+                if (!qualityMenuItem.textContent?.includes("Premium") && !qualityMenuItem.textContent?.includes("プレミアム")) {
                     qualityMenuItem.click();
                     break;
                 }


### PR DESCRIPTION
This PR addresses the issue where the extension would get stuck in a loop when the YouTube display language was set to Japanese (or other non-English languages).

### Changes:
1. **Loop Prevention:** Added a check to see if the settings menu is already open () before clicking the settings button. This prevents the 'toggle' loop that occurred when the quality menu couldn't be found.
2. **Language Support:** Added Japanese translations for 'Quality' (画質) and 'Auto' (自動) to the detection logic.
3. **Robust Detection:** Improved the quality menu detection to look for both labels and content patterns (like '1080p' or 'Auto') which is more resilient across languages.
4. **Ad Detection:** Updated ad detection to be more generic and not rely on the English text 'Ad '.
5. **Premium Check:** Added support for the Japanese label 'プレミアム' in the Premium check.